### PR TITLE
Backport MR21 

### DIFF
--- a/BoardConfigPlatform.mk
+++ b/BoardConfigPlatform.mk
@@ -180,12 +180,7 @@ WIFI_HIDL_FEATURE_DISABLE_AP_MAC_RANDOMIZATION := true
 
 ### BLUETOOTH
 BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := $(PLATFORM_PATH)/bluetooth
-BOARD_HAVE_BLUETOOTH := true
-# Build libbthost_if
-TARGET_USE_QTI_BT_STACK := true
-# We have a rome soc (libbt-vendor)
-# Support libbtnv.so
-QCOM_BT_USE_BTNV := true
+BOARD_HAVE_BLUETOOTH_QCOM := true
 
 ### RIL
 TARGET_RIL_VARIANT := caf

--- a/platform.mk
+++ b/platform.mk
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-# Enable updating of APEXes
-$(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)
-
 PLATFORM_PATH := device/sony/yoshino-common
 
 PRODUCT_SOONG_NAMESPACES += \

--- a/platform/dependencies.mk
+++ b/platform/dependencies.mk
@@ -30,10 +30,6 @@ PRODUCT_PACKAGES += \
     libqcompostprocbundle \
     libvolumelistener
 
-### BLUETOOTH
-PRODUCT_PACKAGES += \
-    libbt-vendor
-
 ### CAMERA
 PRODUCT_PACKAGES += \
     libmmcamera_interface \

--- a/platform/hardware.mk
+++ b/platform/hardware.mk
@@ -17,8 +17,7 @@ PRODUCT_PACKAGES += \
     audio.a2dp.default \
     audio.r_submix.default \
     audio.usb.default \
-    libvolumelistener \
-    bthost_if
+    libvolumelistener
 
 ### CHARGER
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
This backports https://github.com/whatawurst/android_device_sony_yoshino-common/pull/21

Not used:
- yoshino-common: Add fingerprint configuration to overlay 