### PR TITLE
Backport MR 41

### DIFF
--- a/BoardConfigPlatform.mk
+++ b/BoardConfigPlatform.mk
@@ -51,7 +51,6 @@ BOARD_KERNEL_CMDLINE += swiotlb=2048
 BOARD_KERNEL_CMDLINE += androidboot.configfs=true
 BOARD_KERNEL_CMDLINE += androidboot.usbcontroller=a800000.dwc3
 BOARD_KERNEL_CMDLINE += loop.max_part=7
-BOARD_KERNEL_CMDLINE += zram.backend=z3fold
 
 # See README_Xperia in Kernel Source
 BOARD_KERNEL_BASE        := 0x00000000

--- a/config/init/fstab.yoshino
+++ b/config/init/fstab.yoshino
@@ -21,4 +21,4 @@
 /devices/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    defaults                                  voldmanaged=usb:auto
 
 /devices/soc/c0a4900.sdhci/mmc_host*       auto         auto    nosuid,nodev                              wait,voldmanaged=sdcard1:auto
-/dev/block/zram0                           none         swap    defaults                                  zramsize=1073741824,max_comp_streams=8
+/dev/block/zram0                           none         swap    defaults                                  zramsize=2147483648,max_comp_streams=8

--- a/config/init/init.yoshino.rc
+++ b/config/init/init.yoshino.rc
@@ -59,6 +59,9 @@ on init
     # UFS firmware update
     exec u:r:vendor_ffu:s0 -- /vendor/bin/ffu
 
+    # ZRAM setup
+    write /sys/block/zram0/comp_algorithm lz4
+
 on late-init
     mkdir /mnt/tmp 0775
     mount tmpfs tmpfs /mnt/tmp nosuid mode=0775,uid=0,gid=0

--- a/config/init/init.yoshino.rc
+++ b/config/init/init.yoshino.rc
@@ -485,6 +485,9 @@ on boot
 on shutdown
     write /sys/class/power_supply/battery/int_cld 1
 
+on property:persist.sys.locale=*
+    setprop persist.vendor.radio.locale ${persist.sys.locale}
+
 on property:wlan.driver.status=ok
     # WLAN firmware config
     wait /sys/module/wlan/parameters/fwpath

--- a/config/init/init.yoshino.rc
+++ b/config/init/init.yoshino.rc
@@ -67,15 +67,15 @@ on fs
     chown root system /mnt/vendor/persist
     chmod 0771 /mnt/vendor/persist
 
-    restorecon_recursive /mnt/vendor/persist
-    mkdir /mnt/vendor/persist/data 0700 system system
-
     # SONY: create mount points for idd, qns and rca
     mkdir /mnt/idd 0751 oem_2987 oem_2987
     mkdir /mnt/qns 0750 oem_2985 oem_2985
     mkdir /mnt/rca 0750 oem_2987 oem_2987
 
     mount_all /vendor/etc/fstab.${ro.hardware}
+
+    restorecon_recursive /mnt/vendor/persist
+    mkdir /mnt/vendor/persist/data 0700 system system
 
     swapon_all /vendor/etc/fstab.${ro.hardware}
 

--- a/sepolicy/vendor/adsprpcd.te
+++ b/sepolicy/vendor/adsprpcd.te
@@ -1,0 +1,3 @@
+# adsprpcd.te
+
+allow adsprpcd vendor_file:dir r_file_perms;

--- a/sepolicy/vendor/crash_dump.te
+++ b/sepolicy/vendor/crash_dump.te
@@ -2,3 +2,5 @@
 
 allow crash_dump hwservicemanager_prop:file { getattr open };
 allow crash_dump vendor_display_prop:file { getattr open };
+
+allow crash_dump idd_data_file:dir search;

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -45,13 +45,8 @@
 /dev/block/platform/soc/1da4000\.ufshc/by-name/appslog          u:object_r:appslog_block_device:s0
 /dev/block/platform/soc/1da4000\.ufshc/by-name/diag             u:object_r:diag_block_device:s0
 /dev/block/platform/soc/1da4000\.ufshc/by-name/dsp              u:object_r:adsprpc_block_device:s0
-/dev/block/platform/soc/1da4000\.ufshc/by-name/fsc              u:object_r:modem_efs_partition_device:s0
-/dev/block/platform/soc/1da4000\.ufshc/by-name/fsg              u:object_r:modem_efs_partition_device:s0
 /dev/block/platform/soc/1da4000\.ufshc/by-name/idd              u:object_r:idd_block_device:s0
-/dev/block/platform/soc/1da4000\.ufshc/by-name/modemst1         u:object_r:modem_efs_partition_device:s0
-/dev/block/platform/soc/1da4000\.ufshc/by-name/modemst2         u:object_r:modem_efs_partition_device:s0
 /dev/block/platform/soc/1da4000\.ufshc/by-name/oem              u:object_r:oem_block_device:s0
-/dev/block/platform/soc/1da4000\.ufshc/by-name/persist          u:object_r:persist_block_device:s0
 /dev/block/platform/soc/1da4000\.ufshc/by-name/rdimage          u:object_r:ramdump_block_device:s0
 
 /dev/socket/cammw_tintless                                      u:object_r:camera_somc_socket:s0

--- a/sepolicy/vendor/kobjeventd.te
+++ b/sepolicy/vendor/kobjeventd.te
@@ -7,6 +7,8 @@ init_daemon_domain(kobjeventd)
 
 allow kobjeventd self:netlink_kobject_uevent_socket create_socket_perms_no_ioctl;
 
+allow kobjeventd vendor_file:dir r_dir_perms;
+
 # /sys/class/switch
 allow kobjeventd sysfs_switch:dir r_dir_perms;
 allow kobjeventd sysfs_switch:{ file lnk_file } r_file_perms;

--- a/sepolicy/vendor/vendor_pd_mapper.te
+++ b/sepolicy/vendor/vendor_pd_mapper.te
@@ -1,0 +1,3 @@
+# vendor_pd_mapper.te
+
+allow vendor_pd_mapper vendor_file:dir r_dir_perms;


### PR DESCRIPTION
This backports https://github.com/whatawurst/android_device_sony_yoshino-common/pull/41

Not used:
- yoshino-common: sepolicy: Allow bootanim to read userspace_reboot_exported_prop

CC @shank03