### PR TITLE
Lineage 18.1 brightness changes

### DIFF
--- a/config/init/init.yoshino.rc
+++ b/config/init/init.yoshino.rc
@@ -133,6 +133,7 @@ on post-fs
     chown system system /sys/devices/mdss_dsi_panel/c_mode
 
     # backlight
+    chown system system /sys/class/leds/wled/fs_curr_ua
     chown system system /sys/class/leds/wled/bl_scale
     chown system system /sys/class/leds/wled/area_count
 

--- a/hardware/XperiaParts/AndroidManifest.xml
+++ b/hardware/XperiaParts/AndroidManifest.xml
@@ -54,6 +54,18 @@
             </intent-filter>
         </receiver>
 
+        <service
+            android:name="com.yoshino.parts.QSUltraDim"
+            android:icon="@drawable/ic_ultra_dim"
+            android:label="@string/ultra_dim_name"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+            <meta-data android:name="android.service.quicksettings.TOGGLEABLE_TILE" android:value="true" />
+        </service>
+
     </application>
 
 </manifest>

--- a/hardware/XperiaParts/res/drawable/ic_ultra_dim.xml
+++ b/hardware/XperiaParts/res/drawable/ic_ultra_dim.xml
@@ -1,0 +1,49 @@
+<!--
+     Copyright (C) 2021 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M17,12.1L15.59,10.69L13.05,13.22V7.05H11.05V13.22L8.51,10.69L7.1,12.1L12.05,17.05L17,12.1Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M2.05,13.05H4.05C4.6,13.05 5.05,12.6 5.05,12.05C5.05,11.5 4.6,11.05 4.05,11.05H2.05C1.5,11.05 1.05,11.5 1.05,12.05C1.05,12.6 1.5,13.05 2.05,13.05Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M20.05,13.05H22.05C22.6,13.05 23.05,12.6 23.05,12.05C23.05,11.5 22.6,11.05 22.05,11.05H20.05C19.5,11.05 19.05,11.5 19.05,12.05C19.05,12.6 19.5,13.05 20.05,13.05Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M11.05,2.05V4.05C11.05,4.6 11.5,5.05 12.05,5.05C12.6,5.05 13.05,4.6 13.05,4.05V2.05C13.05,1.5 12.6,1.05 12.05,1.05C11.5,1.05 11.05,1.5 11.05,2.05Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M11.05,20.05V22.05C11.05,22.6 11.5,23.05 12.05,23.05C12.6,23.05 13.05,22.6 13.05,22.05V20.05C13.05,19.5 12.6,19.05 12.05,19.05C11.5,19.05 11.05,19.5 11.05,20.05Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M6.04,4.63C5.65,4.24 5.01,4.24 4.63,4.63C4.24,5.02 4.24,5.66 4.63,6.04L5.69,7.1C6.08,7.49 6.72,7.49 7.1,7.1C7.49,6.71 7.49,6.07 7.1,5.69L6.04,4.63Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M18.41,17C18.02,16.61 17.38,16.61 17,17C16.61,17.39 16.61,18.03 17,18.41L18.06,19.47C18.45,19.86 19.09,19.86 19.47,19.47C19.86,19.08 19.86,18.44 19.47,18.06L18.41,17Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M19.47,6.04C19.86,5.65 19.86,5.01 19.47,4.63C19.08,4.24 18.44,4.24 18.06,4.63L17,5.69C16.61,6.08 16.61,6.72 17,7.1C17.39,7.49 18.03,7.49 18.41,7.1L19.47,6.04Z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M7.1,18.41C7.49,18.02 7.49,17.38 7.1,17C6.71,16.61 6.07,16.61 5.69,17L4.63,18.06C4.24,18.45 4.24,19.09 4.63,19.47C5.02,19.86 5.66,19.86 6.04,19.47L7.1,18.41Z"
+        android:fillColor="#ffffff"/>
+</vector>

--- a/hardware/XperiaParts/res/values/strings.xml
+++ b/hardware/XperiaParts/res/values/strings.xml
@@ -37,4 +37,7 @@
     <string name="sim_slot_summary">Select the sim slot you want network switcher to work for.\nSelected Slot:</string>
     <string name="ims_title">IMS Features</string>
     <string name="ims_summary">Enables features such as IMS, VoLTE, VoWiFi or WiFi calling <b>if it worked on stock</b>.</string>
+    <string name="ultra_dim_name">Ultra-Dim</string>
+    <string name="ultra_dim_label_enabled">Restore screen brightness</string>
+    <string name="ultra_dim_label_disabled">Reduce screen brightness</string>
 </resources>

--- a/hardware/XperiaParts/src/com/yoshino/parts/BootReceiver.java
+++ b/hardware/XperiaParts/src/com/yoshino/parts/BootReceiver.java
@@ -24,6 +24,7 @@ import static com.yoshino.parts.Constants.GLOVE_MODE;
 import static com.yoshino.parts.Constants.GLOVE_PROP;
 import static com.yoshino.parts.Constants.SMART_STAMINA_MODE;
 import static com.yoshino.parts.Constants.SMART_STAMINA_PROP;
+import com.yoshino.parts.QSUltraDim;
 
 public class BootReceiver extends BroadcastReceiver {
 
@@ -38,5 +39,7 @@ public class BootReceiver extends BroadcastReceiver {
 
         boolean isSmartStaminaModeEnabled = Settings.System.getInt(context.getContentResolver(), SMART_STAMINA_MODE, 0) == 1;
         SystemProperties.set(SMART_STAMINA_PROP, isSmartStaminaModeEnabled ? "1" : "0");
+
+        QSUltraDim.init(context);
     }
 }

--- a/hardware/XperiaParts/src/com/yoshino/parts/Constants.java
+++ b/hardware/XperiaParts/src/com/yoshino/parts/Constants.java
@@ -31,4 +31,9 @@ public class Constants {
 
     public static final String NS_SLOT = "ns_slot";
     public static final String NS_SERVICE = "ns_service";
+
+    public static final String ULTRA_DIM = "ultra_dim";
+    public static final String ULTRA_DIM_DEFAULT_PROP = "vendor.ultra_dim.default";
+    public static final String ULTRA_DIM_LOW_PROP = "vendor.ultra_dim.low";
+    public static final String ULTRA_DIM_FILE = "/sys/class/leds/wled/fs_curr_ua";
 }

--- a/hardware/XperiaParts/src/com/yoshino/parts/QSUltraDim.java
+++ b/hardware/XperiaParts/src/com/yoshino/parts/QSUltraDim.java
@@ -1,0 +1,113 @@
+package com.yoshino.parts;
+
+import android.content.Context;
+import android.os.SystemProperties;
+import android.provider.Settings;
+import android.service.quicksettings.Tile;
+import android.service.quicksettings.TileService;
+import android.util.Log;
+import java.io.File;
+import java.io.FileReader;
+import java.io.PrintWriter;
+import java.io.BufferedReader;
+import com.yoshino.parts.Constants;
+import com.yoshino.parts.BootReceiver;
+
+public class QSUltraDim extends TileService {
+
+    private static final String TAG = "QSUltraDim";
+    private static int defaultValue = 0;
+    private static int lowValue = 5000;
+    private boolean mIsSupported = false;
+
+    private static int readFSCurr() {
+        try {
+            File file = new File(Constants.ULTRA_DIM_FILE);
+            if (file.exists()) {
+                BufferedReader br = new BufferedReader(new FileReader(file));
+                String data = br.readLine();
+                br.close();
+                Log.d(TAG, "Read FSCurr: " + data);
+                return Integer.parseInt(data);
+            } else {
+                return -1;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return -1;
+        }
+    }
+
+    private static void setValue(Context context, boolean enabled) {
+        int value;
+        if (enabled)
+            value = lowValue;
+        else
+            value = (defaultValue > 0) ? defaultValue : 17500;
+        Log.d(TAG, "writeUltraDim: Setting to " + value);
+        Settings.System.putInt(context.getContentResolver(), Constants.ULTRA_DIM, enabled ? 1 : 0);
+        try {
+            PrintWriter writer = new PrintWriter(new File(Constants.ULTRA_DIM_FILE));
+            writer.println(value);
+            writer.flush();
+            writer.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    
+    private boolean isEnabled() {
+        return isEnabled(this);
+    }
+
+    private static boolean isEnabled(Context context) {
+        return Settings.System.getInt(context.getContentResolver(), Constants.ULTRA_DIM, 0) != 0;
+    }
+
+    private static void readConfigProperties() {
+        if(defaultValue == 0) {
+            defaultValue = SystemProperties.getInt(Constants.ULTRA_DIM_DEFAULT_PROP, -1);
+            lowValue = SystemProperties.getInt(Constants.ULTRA_DIM_LOW_PROP, 5000);
+        }
+    }
+
+    /// Init after Boot
+    public static void init(Context context) {
+        // Read defaults possibly set by device-specific config
+        readConfigProperties();
+        // If unset read from sysfs and set property in case the service crashes and is restarted
+        if(defaultValue == -1) {
+            defaultValue = readFSCurr();
+            SystemProperties.set(Constants.ULTRA_DIM_DEFAULT_PROP, String.valueOf(defaultValue));
+        }
+        if (isEnabled(context) && defaultValue > 0)
+            setValue(context, true);
+    }
+
+    private void updateTile(boolean enabled) {
+        Tile tile = getQsTile();
+        if(!mIsSupported)
+            tile.setState(Tile.STATE_UNAVAILABLE);
+        else
+            tile.setState(enabled ? Tile.STATE_ACTIVE : Tile.STATE_INACTIVE);
+        tile.setSubtitle(getString(enabled ? R.string.ultra_dim_label_enabled : R.string.ultra_dim_label_disabled));
+        tile.updateTile();
+    }
+
+    @Override
+    public void onClick() {
+        if(!mIsSupported)
+            return;
+        final boolean enabled = !isEnabled();
+        Log.i(TAG, "Setting to " + enabled);
+        setValue(this, enabled);
+        updateTile(enabled);
+    }
+
+    @Override
+    public void onStartListening() {
+        readConfigProperties();
+        mIsSupported = defaultValue > 0;
+        updateTile(isEnabled());
+    }
+}

--- a/hardware/lights/Android.bp
+++ b/hardware/lights/Android.bp
@@ -1,0 +1,36 @@
+//
+// Copyright (C) 2018 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+cc_binary {
+    name: "android.hardware.light@2.0-service.yoshino",
+    relative_install_path: "hw",
+    init_rc: ["android.hardware.light@2.0-service.yoshino.rc"],
+    vintf_fragments: ["android.hardware.light@2.0-service.yoshino.xml"],
+    srcs: ["service.cpp", "Light.cpp"],
+    cflags: [
+        "-Wall",
+        "-Werror",
+        "-DLOG_TAG=\"lights.sony\"",
+    ],
+    shared_libs: [
+        "libcutils",
+        "libbase",
+        "libutils",
+        "libhardware",
+        "libhidlbase",
+        "android.hardware.light@2.0",
+    ],
+    proprietary: true,
+}

--- a/hardware/lights/Light.cpp
+++ b/hardware/lights/Light.cpp
@@ -1,0 +1,306 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ * Copyright (C) 2018 Shane Francis
+ * Copyright (C) 2022 Alexander Grund
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Light.h"
+#include <android-base/logging.h>
+#include <cutils/properties.h>
+#include <fstream>
+#include <stdexcept>
+#include <thread>
+
+#define LEDS_CLASS_BASE "/sys/class/leds/"
+#define LED_FILE(led, file) LEDS_CLASS_BASE #led "/" #file
+
+constexpr const char* BUTTON_FILE = LED_FILE(button-backlight, brightness);
+
+constexpr const char* LCD_CLASS_BASE = "/sys/class/leds/lcd-backlight";
+constexpr const char* LCD_CLASS_BASE2 = "/sys/class/backlight/panel0-backlight";
+static const char* PERSISTENCE_FILE = "/sys/class/graphics/fb0/msm_fb_persist_mode";
+constexpr int32_t DEFAULT_LOW_PERSISTENCE_MODE_BRIGHTNESS = 128;
+constexpr const char* LP_MODE_BRIGHTNESS_PROPERTY = "sys.display.low_persistence_mode_brightness";
+
+using ::android::hardware::light::V2_0::LightState;
+
+static bool exists(const char* path) {
+    return access(path, F_OK) == 0;
+}
+
+static bool exists(const std::string& path) {
+    return exists(path.c_str());
+}
+
+template<typename T>
+static bool write(const char* path, const T& value) {
+    std::ofstream stream(path);
+
+    if (!stream) {
+        PLOG(ERROR) << "Failed to open " << path;
+        return false;
+    }
+
+    if (stream << value << std::endl)
+        return true;
+    PLOG(ERROR) << "Failed to write to " << path;
+    return false;
+}
+
+template<typename T>
+static bool read(const char* path, T& value) {
+    std::ifstream stream(path);
+
+    if (!stream) {
+        PLOG(ERROR) << "Failed to open " << path;
+        return false;
+    }
+
+    if (stream >> value)
+        return true;
+    PLOG(ERROR) << "Failed to read from " << path;
+    return false;
+}
+
+template<typename T>
+static T read(const char* path) {
+    T result;
+    return read(path, result) ? T{} : result;
+}
+
+static bool isLit(const LightState &state) {
+    return state.color & 0x00ffffff;
+}
+
+static int rgbToBrightness(const LightState &state) {
+    const int color = state.color;
+    return ((77 * ((color >> 16) & 0x00ff))
+               + (150 * ((color >> 8) & 0x00ff)) + (29 * (color & 0x00ff)))
+        >> 8;
+}
+
+/// Scale a color value (0-255) to the range 0-maxBrightness
+static int scaleBrightness(const int brightness, const int maxBrightness) {
+    // Adding half of the max (255/2=127) provides proper rounding while staying in integer mode
+    return (brightness * maxBrightness + 127) / 255;
+}
+
+static void readMaxBrightness(const char* file, int& maxBrightness, const char* name, int defaultValue = -1) {
+    if(read(file, maxBrightness) < 0) {
+        LOG(WARNING) << "Can't read max brightness for " << name;
+        maxBrightness = defaultValue;
+    } else if (maxBrightness < 0) {
+        LOG(WARNING) << "Max brightness value " << maxBrightness << " for " << name << " is invalid";
+        maxBrightness = defaultValue;
+    }
+}
+
+namespace android {
+namespace hardware {
+namespace light {
+namespace V2_0 {
+namespace implementation {
+
+Light::Color::Color(const unsigned colorRGB):
+    red((colorRGB >> 16) & 0xFF),
+    green((colorRGB >> 8) & 0xFF),
+    blue(colorRGB & 0xFF)
+{}
+
+Light::Light() {
+    android::base::SetMinimumLogSeverity(android::base::LogSeverity::VERBOSE);
+
+    LOG(INFO) << __func__ << ": Setup HAL";
+
+    // Assume those always exist
+    std::vector<Type> supportedTypes{
+        Type::BACKLIGHT,
+        Type::BATTERY,
+        Type::NOTIFICATIONS,
+        Type::ATTENTION,
+    };
+
+    const std::string lcd_class_base = exists(LCD_CLASS_BASE) ? LCD_CLASS_BASE : LCD_CLASS_BASE2;
+    mLcdFile = lcd_class_base + "/brightness";
+    if(!exists(mLcdFile)) {
+        LOG(FATAL) << "Unknown LCD";
+    }
+    
+    readMaxBrightness((lcd_class_base + "/max_brightness").c_str(), mBacklightMax, "LCD");
+    readMaxBrightness(LED_FILE(red, max_single_brightness), mMaxSingle.red, "red LED", 0xFF);
+    readMaxBrightness(LED_FILE(green, max_single_brightness), mMaxSingle.green, "green LED", 0xFF);
+    readMaxBrightness(LED_FILE(blue, max_single_brightness), mMaxSingle.blue, "blue LED", 0xFF);
+    readMaxBrightness(LED_FILE(red, max_mix_brightness), mMaxMix.red, "red LED(mix)", 0xFF);
+    readMaxBrightness(LED_FILE(green, max_mix_brightness), mMaxMix.green, "green LED(mix)", 0xFF);
+    readMaxBrightness(LED_FILE(blue, max_mix_brightness), mMaxMix.blue, "blue LED(mix)", 0xFF);
+
+    mHasPersistenceFile = exists(PERSISTENCE_FILE);
+    mHasButtonFile = exists(BUTTON_FILE);
+    if(mHasButtonFile)
+        supportedTypes.push_back(Type::BUTTONS);
+    mSupportedTypes = supportedTypes;
+}
+
+Return<Status> Light::setLight(Type type, const LightState &state) {
+    bool status;
+    switch (type) {
+    case Type::BACKLIGHT:
+        LOG(DEBUG) << __func__ << " : Type::BACKLIGHT";
+        status = setLightBacklight(state);
+        break;
+    case Type::BUTTONS:
+        LOG(DEBUG) << __func__ << " : Type::BUTTONS";
+        return setLightButtons(state);
+    case Type::BATTERY:
+        LOG(DEBUG) << __func__ << " : Type::BATTERY";
+        status = setLightBattery(state);
+        break;
+    case Type::NOTIFICATIONS:
+        LOG(DEBUG) << __func__ << " : Type::NOTIFICATIONS";
+        status = setLightNotifications(state);
+        break;
+    case Type::ATTENTION:
+        LOG(DEBUG) << __func__ << " : Type::ATTENTION";
+        status = setLightNotifications(state);
+        break;
+    case Type::KEYBOARD:
+    case Type::BLUETOOTH:
+    case Type::WIFI:
+        return Status::LIGHT_NOT_SUPPORTED;
+    default:
+        LOG(DEBUG) << __func__ << " : Unknown light type " << static_cast<int32_t>(type);
+        return Status::LIGHT_NOT_SUPPORTED;
+    }
+    return status ? Status::SUCCESS : Status::UNKNOWN;
+}
+
+bool Light::setLightBacklight(const LightState &state) {
+    std::lock_guard<std::mutex> lock(mLcdLock);
+
+    bool status = true;
+    int brightness = rgbToBrightness(state);
+    const bool lpEnabled = state.brightnessMode == Brightness::LOW_PERSISTENCE;
+
+    const bool cannotHandlePersistence = !mHasPersistenceFile && lpEnabled;
+    // If persistence mode has been changed
+    if (mHasPersistenceFile && mLowPersistenceEnabled != lpEnabled) {
+        if ((status = write(PERSISTENCE_FILE, lpEnabled ? 1 : 0)))
+            LOG(ERROR) << __func__ << " : Failed to write to " << PERSISTENCE_FILE << ": " << strerror(errno);
+        if (lpEnabled)
+            brightness = property_get_int32(LP_MODE_BRIGHTNESS_PROPERTY, DEFAULT_LOW_PERSISTENCE_MODE_BRIGHTNESS);
+        mLowPersistenceEnabled = lpEnabled;
+    }
+
+    if (status) {
+        if (brightness && mBacklightMax > 0) {
+            // Scale by max brightness but make sure the min and max values are 1 and max_lcd_brightness
+            brightness = (brightness == 255) ? mBacklightMax : scaleBrightness(brightness - 1, mBacklightMax) + 1;
+        }
+        status = write(mLcdFile.c_str(), brightness);
+    }
+
+    return !cannotHandlePersistence && status;
+}
+
+bool write_lut(const char* file, int brightness) {
+    char buffer[22];
+    int n = snprintf(buffer, sizeof(buffer), "%d,0\n", brightness);
+    if (n < 0 || n >= sizeof(buffer))
+        return false;
+    return write(file, buffer);
+}
+
+#define HANDLE_LED_BLINK_VALUES(led)                            \
+    if (color.led) {                                            \
+        status &= write_lut(LED_FILE(led, lut_pwm), color.led); \
+        status &= write(LED_FILE(led, pause_lo_multi), onMS);   \
+        status &= write(LED_FILE(led, pause_hi_multi), offMS);  \
+        status &= write(LED_FILE(led, step_duration), 0);       \
+    }
+
+bool Light::setSpeakerLightLocked(const LightState &state) {
+    Color color(state.color);
+    const Color maxColor = ((color.red != 0) + (color.green != 0) + (color.blue != 0) > 1) ? mMaxMix : mMaxSingle;
+    color.red = scaleBrightness(color.red, maxColor.red);
+    color.green = scaleBrightness(color.green, maxColor.green);
+    color.blue = scaleBrightness(color.blue, maxColor.blue);
+
+    const int onMS = state.flashOnMs;
+    const int offMS = state.flashOffMs;
+    bool status;
+    if (state.flashMode != Flash::NONE) {
+        // Setup synchronized blinking
+        status = write(LED_FILE(rgb, sync_state), 1);
+        HANDLE_LED_BLINK_VALUES(red)
+        HANDLE_LED_BLINK_VALUES(green)
+        HANDLE_LED_BLINK_VALUES(blue)
+        // And start
+        status &= write(LED_FILE(rgb, start_blink), 1);
+        mIsBlinking = true;
+    } else {
+        if (mIsBlinking) {
+            // Disable blinking
+            write(LED_FILE(rgb, sync_state), 0);
+            mIsBlinking = false;
+        }
+        status = write(LED_FILE(red, brightness), color.red) && 
+            write(LED_FILE(green, brightness), color.green) && 
+            write(LED_FILE(blue, brightness), color.blue);
+    }
+
+#if 1
+    LOG(DEBUG) << "set_speaker_light_locked mode " << static_cast<int>(state.flashMode) <<
+            " colorRGB=" << state.color << " onMS=" << onMS << " offMS=" << offMS << " result: " << status;
+#endif
+
+    return status;
+}
+
+Status Light::setLightButtons(const LightState &state) {
+    if(!mHasButtonFile)
+        return Status::LIGHT_NOT_SUPPORTED;
+    std::lock_guard<std::mutex> lock(mLock);
+    return write(BUTTON_FILE, static_cast<int>(state.color & 0xFF)) ? Status::SUCCESS : Status::UNKNOWN;
+}
+
+bool Light::handleSpeakerBatteryLocked() {
+    if (isLit(batteryState)) {
+        return setSpeakerLightLocked(batteryState);
+    } else {
+         return setSpeakerLightLocked(notificationState);
+    }
+}
+
+bool Light::setLightBattery(const LightState &state) {
+    std::lock_guard<std::mutex> lock(mLock);
+    batteryState = state;
+    return handleSpeakerBatteryLocked();
+}
+
+bool Light::setLightNotifications(const LightState &state) {
+    std::lock_guard<std::mutex> lock(mLock);
+    notificationState = state;
+    return handleSpeakerBatteryLocked();
+}
+
+Return<void> Light::getSupportedTypes(getSupportedTypes_cb _hidl_cb) {
+    _hidl_cb(mSupportedTypes);
+    return Void();
+}
+} // namespace implementation
+} // namespace V2_0
+} // namespace light
+} // namespace hardware
+} // namespace android

--- a/hardware/lights/Light.h
+++ b/hardware/lights/Light.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ * Copyright (C) 2018 Shane Francis
+ * Copyright (C) 2022 Alexander Grund
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef ANDROID_HARDWARE_LIGHT_V2_0_LIGHT_H
+#define ANDROID_HARDWARE_LIGHT_V2_0_LIGHT_H
+
+#include <android/hardware/light/2.0/ILight.h>
+#include <hidl/Status.h>
+
+#include <array>
+#include <mutex>
+
+namespace android {
+namespace hardware {
+namespace light {
+namespace V2_0 {
+namespace implementation {
+using ::android::hardware::Return;
+using ::android::hardware::light::V2_0::ILight;
+using ::android::hardware::light::V2_0::LightState;
+using ::android::hardware::light::V2_0::Status;
+using ::android::hardware::light::V2_0::Type;
+
+class Light : public ILight {
+public:
+    Light();
+
+    // Methods from ::android::hardware::light::V2_0::ILight follow.
+    Return<Status> setLight(Type type, const LightState &state) override;
+    Return<void> getSupportedTypes(getSupportedTypes_cb _hidl_cb) override;
+
+private:
+    struct Color {
+        Color() = default;
+        Color(unsigned int);
+        int red, green, blue;
+    };
+
+    std::mutex mLock, mLcdLock;
+    std::string mLcdFile;
+    int mBacklightMax = 0;
+    // Max values for the RGB LED(s)
+    Color mMaxSingle, mMaxMix;
+
+    bool mHasButtonFile, mHasPersistenceFile;
+    bool mLowPersistenceEnabled = false;
+    bool mIsBlinking = false;
+    LightState batteryState;
+    LightState notificationState;
+
+    hidl_vec<Type> mSupportedTypes;
+
+    bool setLightBacklight(const LightState &state);
+    bool setLightBattery(const LightState &state);
+    bool setLightNotifications(const LightState &state);
+    Status setLightButtons(const LightState &state);
+    bool handleSpeakerBatteryLocked();
+    bool setSpeakerLightLocked(const LightState &state);
+};
+} // namespace implementation
+} // namespace V2_0
+} // namespace light
+} // namespace hardware
+} // namespace android
+
+#endif // ANDROID_HARDWARE_LIGHT_V2_0_LIGHT_H

--- a/hardware/lights/android.hardware.light@2.0-service.yoshino.rc
+++ b/hardware/lights/android.hardware.light@2.0-service.yoshino.rc
@@ -1,0 +1,7 @@
+service vendor.light-hal-2-0 /vendor/bin/hw/android.hardware.light@2.0-service.yoshino
+    interface android.hardware.light@2.0::ILight default
+    class hal
+    user system
+    group system
+    # shutting off lights while powering-off
+    shutdown critical

--- a/hardware/lights/android.hardware.light@2.0-service.yoshino.xml
+++ b/hardware/lights/android.hardware.light@2.0-service.yoshino.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device">
+     <hal format="hidl" override="true">
+        <name>android.hardware.light</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>ILight</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>

--- a/hardware/lights/service.cpp
+++ b/hardware/lights/service.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 The Android Open Source Project
+ * Copyright 2018 Shane Francis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Light.h"
+#include <android-base/logging.h>
+#include <android/hardware/light/2.0/ILight.h>
+#include <hidl/HidlSupport.h>
+#include <hidl/HidlTransportSupport.h>
+
+using android::NO_ERROR;
+using android::sp;
+using android::hardware::configureRpcThreadpool;
+using android::hardware::joinRpcThreadpool;
+using android::hardware::light::V2_0::ILight;
+using android::hardware::light::V2_0::implementation::Light;
+
+int main()
+{
+    LOG(INFO) << __func__ << " : Start HAL";
+    android::sp<ILight> light = new Light();
+
+    configureRpcThreadpool(1, true /*callerWillJoin*/);
+
+    if (light != nullptr) {
+        auto rc = light->registerAsService();
+        if (rc != NO_ERROR) {
+            LOG(ERROR) << "Cannot start Light service: " << rc;
+            return rc;
+        }
+    } else {
+        LOG(ERROR) << "Can't create instance of Light, nullptr";
+    }
+
+    joinRpcThreadpool();
+}

--- a/platform/hardware.mk
+++ b/platform/hardware.mk
@@ -139,9 +139,14 @@ PRODUCT_PACKAGES += \
     android.hardware.health@2.1-service
 
 # LIGHT
-PRODUCT_PACKAGES += \
-    android.hardware.light@2.0-impl \
-    android.hardware.light@2.0-service
+ifneq ($(TARGET_USE_YOSHINO_LIGHT_SERVICE),true)
+    PRODUCT_PACKAGES += \
+        android.hardware.light@2.0-impl \
+        android.hardware.light@2.0-service
+else
+    TARGET_PROVIDES_LIBLIGHT := true
+    PRODUCT_PACKAGES += android.hardware.light@2.0-service.yoshino
+endif
 
 # MEMTRACK
 PRODUCT_PACKAGES += \

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -144,6 +144,7 @@
 /(vendor|system/vendor)/bin/hw/kobjeventd                       u:object_r:kobjeventd_exec:s0
 /(vendor|system/vendor)/bin/hw/touchbacklightd                  u:object_r:touchbacklightd_exec:s0
 /(vendor|system/vendor)/bin/hw/vendor\.semc\.hardware\.light@1\.0-service   u:object_r:hal_light_default_exec:s0
+/(vendor|system/vendor)/bin/hw/android\.hardware\.light@2\.0-service\.yoshino  u:object_r:hal_light_default_exec:s0
 /(vendor|system/vendor)/bin/hw/android\.hardware\.power@1\.3-service\.yoshino      u:object_r:hal_power_default_exec:s0
 /(vendor|system/vendor)/bin/hw/vendor\.semc\.hardware\.secd@1\.0-service    u:object_r:hal_secd_default_exec:s0
 /(vendor|system/vendor)/bin/hw/vendor\.semc\.hardware\.thermal@(.*)?    u:object_r:hal_somc_thermal_daemon_exec:s0

--- a/sepolicy/vendor/property.te
+++ b/sepolicy/vendor/property.te
@@ -15,6 +15,7 @@ type vendor_cover_state_prop, property_type;
 type vendor_pcc_mdp_prop, property_type;
 type vendor_semc_version_cust_active_prop, property_type;
 type vendor_somc_hdcp_prop, property_type;
+type vendor_ultradim_prop, property_type;
 type wfd_prop, property_type;
 type wifi_active_prop, property_type;
 type wigig_prop, property_type;

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -23,5 +23,6 @@ vendor.powerhal.                       u:object_r:vendor_power_prop:s0
 vendor.somc.hdcp.                    u:object_r:vendor_somc_hdcp_prop:s0
 vendor.cover_state                   u:object_r:vendor_cover_state_prop:s0
 vendor.smartstamina.touchreport      u:object_r:vendor_clearpad_prop:s0
+vendor.ultra_dim.                    u:object_r:vendor_ultradim_prop:s0
 
 wifi.active.interface                u:object_r:wifi_active_prop:s0

--- a/sepolicy/vendor/seapp_contexts
+++ b/sepolicy/vendor/seapp_contexts
@@ -1,1 +1,2 @@
 user=radio seinfo=platform name=.qtidataservices domain=qtidataservices_app type=radio_data_file
+user=system seinfo=platform name=com.yoshino.parts domain=xperia_parts_app type=system_app_data_file

--- a/sepolicy/vendor/system_app.te
+++ b/sepolicy/vendor/system_app.te
@@ -15,7 +15,3 @@ allow system_app proc_vmallocinfo:file { r_file_perms };
 get_prop(system_app, wfd_prop)
 # dataservice_app
 get_prop(system_app, vendor_cnd_vendor_prop)
-
-# Allow Xperia Parts to enable/disable SmartStamina
-set_prop(system_app, vendor_clearpad_prop)
-get_prop(system_app, vendor_clearpad_prop)

--- a/sepolicy/vendor/xperia_parts_app.te
+++ b/sepolicy/vendor/xperia_parts_app.te
@@ -1,0 +1,17 @@
+type xperia_parts_app, domain;
+
+app_domain(xperia_parts_app)
+allow xperia_parts_app activity_service:service_manager find;
+# R/W of system properties
+set_prop(xperia_parts_app, system_prop)
+set_prop(xperia_parts_app, exported_system_prop)
+set_prop(xperia_parts_app, exported2_system_prop)
+set_prop(xperia_parts_app, exported3_system_prop)
+set_prop(xperia_parts_app, dynamic_system_prop)
+
+# Read and write /data/data subdirectory.
+allow xperia_parts_app system_app_data_file:dir create_dir_perms;
+allow xperia_parts_app system_app_data_file:{ file lnk_file } create_file_perms;
+
+# Allow Xperia Parts to enable/disable SmartStamina
+set_prop(xperia_parts_app, vendor_clearpad_prop)

--- a/sepolicy/vendor/xperia_parts_app.te
+++ b/sepolicy/vendor/xperia_parts_app.te
@@ -15,3 +15,8 @@ allow xperia_parts_app system_app_data_file:{ file lnk_file } create_file_perms;
 
 # Allow Xperia Parts to enable/disable SmartStamina
 set_prop(xperia_parts_app, vendor_clearpad_prop)
+
+# Also set backlight brightness
+set_prop(xperia_parts_app, vendor_ultradim_prop)
+allow xperia_parts_app sysfs_leds:dir r_dir_perms;
+allow xperia_parts_app sysfs_leds:file rw_file_perms;


### PR DESCRIPTION
- Use a custom HAL to use the full brightness range of the LCD (1-max_brightness)
- Add QuickSettings tile to reduce max LCD current scaling down all brightness settings
- Some SEPolicy changes

@linckandrea @shank03 Might be of interest to you. 
@derfelot If you are interested in anything of this let me know which and I'll rebase and PR those commits onto your 18.1 branch.

This is tested on lilac, but I assume is generic enough for all yoshino devices.
It also requires the removal of the custom lights service (i.e. illumination_service and vendor.semc.hardware.light@1.0-service), see https://github.com/Flamefire/android_device_sony_lilac/commit/4fe23c0d94613f8b45f9d4ae5c1dd70c7ad2537d

Used repos/implementations for reference (especially regarding the LCD):
-  https://github.com/sonyxperiadev/vendor-qcom-opensource-display/blob/aosp/LA.UM.9.14.r1/liblight/lights.c
- https://github.com/sonyxperiadev/device-sony-common/blob/fc6d709db9b4f44e8bfb410d8c7e7e67ca292a6a/hardware/liblights/Light.cpp

Edit: Note that I had to revert to using properties and an init trigger due to secondary SELinux issues which requires XperiaParts to be a system_app which in turn disallows access to sysfs. See https://github.com/Flamefire/android_device_sony_yoshino-common/commit/9b6b3c09e74ddcbb8e09e87a67a3a1be4f6abd4b