### PR TITLE
Fix SELinux denials (mostly with etx4 SD cards)

### DIFF
--- a/sepolicy/vendor/app.te
+++ b/sepolicy/vendor/app.te
@@ -1,0 +1,4 @@
+# Access OBBs (sdcard_posix) mounted by vold
+# File write access allowed for FDs returned through Storage Access Framework
+allow appdomain sdcard_posix_contextmount_type:dir getattr;
+allow appdomain sdcard_posix_contextmount_type:file { read write append getattr lock };

--- a/sepolicy/vendor/bluetooth.te
+++ b/sepolicy/vendor/bluetooth.te
@@ -1,3 +1,4 @@
 # bluetooth.te
 
 get_prop(bluetooth, semc_product_prop)
+binder_call(bluetooth, gpuservice)

--- a/sepolicy/vendor/fsck_untrusted.te
+++ b/sepolicy/vendor/fsck_untrusted.te
@@ -1,2 +1,5 @@
+allow fsck_untrusted media_rw_data_file:dir r_dir_perms;
+allow fsck_untrusted proc_swaps:file r_file_perms;
+
 # Gets denied despite rw_file_perms
 allow fsck_untrusted vold_device:blk_file ioctl;

--- a/sepolicy/vendor/platform_app.te
+++ b/sepolicy/vendor/platform_app.te
@@ -5,3 +5,8 @@ allow platform_app cacaoserver_service:service_manager find;
 
 get_prop(platform_app, semc_version_prop)
 get_prop(platform_app, vendor_semc_version_cust_active_prop)
+
+# Direct access to vold-mounted storage under /mnt/media_rw
+# This is a performance optimization that allows platform apps to bypass the FUSE layer
+allow platform_app sdcard_posix_contextmount_type:dir create_dir_perms;
+allow platform_app sdcard_posix_contextmount_type:file create_file_perms;

--- a/sepolicy/vendor/system_server.te
+++ b/sepolicy/vendor/system_server.te
@@ -11,4 +11,7 @@ allow system_server vendor_idc_file:file r_file_perms;
 # neverallow /mnt/media_rw/[A-Z0-9]-[A-Z0-9]/Android/data
 # allow system_server vfat:dir r_dir_perms;
 
+# neverallow for sdcard_type:dir prohibits this
+# allow system_server sdcard_posix:dir r_dir_perms;
+
 allow system_server app_zygote:process getpgid;


### PR DESCRIPTION
Fixes the denials found while testing https://github.com/Flamefire/android_kernel_sony_msm8998/pull/13#issuecomment-1043045243

However this still results in denials:
> avc: denied { create } for name="sdcard_write_test" scontext=u:r:platform_app:s0:c512,c768 tcontext=u:object_r:sdcard_posix:s0 tclass=file permissive=0 ppid=754 pcomm="main" pgid=6114 pgcomm="externalstorage" app=com.android.externalstorage

With a suggested fix:
> allow platform_app sdcard_posix:file create;

And another I haven't addressed so far:
> #============= installd ==============
allow installd sdcard_posix:filesystem quotaget;

However I can't do that as `sdcard_posix` is private in `device/lineage/sepolicy/common/private/file.te`
> type sdcard_posix, sdcard_type, sdcard_posix_contextmount_type, fs_type, mlstrustedobject;

Strange enough the file `system/sepolicy/private/platform_app.te` already has: 
> allow platform_app sdcard_type:file create_file_perms;

So I have no idea why this fails. Any idea @bananafunction ?