### PR TITLE
Accomodating PR 23 from `android_device_sony_lilac`

### DIFF
--- a/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/Configurator.java
+++ b/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/Configurator.java
@@ -106,7 +106,7 @@ public class Configurator {
             } catch (IOException e) {
                 CSLog.w(TAG, "Unable to read out current configuration");
             	// Actual: (this.mConfigId == null && TextUtils.isEmpty(this.mModem)) ? false : true
-				return mConfigId != null || !TextUtils.isEmpty(mModem);
+		return mConfigId != null || !TextUtils.isEmpty(mModem);
             }
         } else {
             CSLog.d(TAG, "isNewConfigurationNeeded - ConfigKey not updated, no need to evaluate");

--- a/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/Configurator.java
+++ b/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/Configurator.java
@@ -101,8 +101,13 @@ public class Configurator {
                 CSLog.d(TAG, "isNewConfigurationNeeded - Modem: " + mModem);
                 CSLog.d(TAG, "isNewConfigurationNeeded - Carrier Config Id: " + mConfigId);
             }
-            // Actual: (this.mConfigId == null && TextUtils.isEmpty(this.mModem)) ? false : true
-            return mConfigId != null || !TextUtils.isEmpty(mModem);
+            try {
+                return (mConfigId != null || !TextUtils.isEmpty(mModem)) && !ModemSwitcher.getCurrentModemConfig().equals(mModem);
+            } catch (IOException e) {
+                CSLog.w(TAG, "Unable to read out current configuration");
+            	// Actual: (this.mConfigId == null && TextUtils.isEmpty(this.mModem)) ? false : true
+				return mConfigId != null || !TextUtils.isEmpty(mModem);
+            }
         } else {
             CSLog.d(TAG, "isNewConfigurationNeeded - ConfigKey not updated, no need to evaluate");
             return false;

--- a/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/ImsSwitcher.java
+++ b/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/ImsSwitcher.java
@@ -22,7 +22,7 @@ public class ImsSwitcher {
     public void switchOnIMS(int subID) {
         CSLog.d(TAG, "switching IMS ON");
         // Need to reset configuration preference in order to allow reboot dialog to appear.
-        if (!context.getSharedPreferences(Configurator.PREF_PKG, Context.MODE_PRIVATE).edit().putString(Configurator.OLD_CONFIG_KEY, "").commit()) {
+        if (!context.createDeviceProtectedStorageContext().getSharedPreferences(Configurator.PREF_PKG, Context.MODE_PRIVATE).edit().putString(Configurator.OLD_CONFIG_KEY, "").commit()) {
             CSLog.w(TAG, "switchOnIMS: Failed to reset configuration key, modem will not be changed.");
 }
 

--- a/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/ImsSwitcher.java
+++ b/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/ImsSwitcher.java
@@ -22,8 +22,9 @@ public class ImsSwitcher {
     public void switchOnIMS(int subID) {
         CSLog.d(TAG, "switching IMS ON");
         // Need to reset configuration preference in order to allow reboot dialog to appear.
-        context.createDeviceProtectedStorageContext().getSharedPreferences(Configurator.PREF_PKG, Context.MODE_PRIVATE)
-                .edit().putString(Configurator.OLD_CONFIG_KEY, "null").apply();
+        if (!context.getSharedPreferences(Configurator.PREF_PKG, Context.MODE_PRIVATE).edit().putString(Configurator.OLD_CONFIG_KEY, "").commit()) {
+            CSLog.w(TAG, "switchOnIMS: Failed to reset configuration key, modem will not be changed.");
+}
 
         if (CommonUtil.isDefaultDataSlot(context, subID)) {
             CSLog.d(TAG, "Default data SIM loaded");

--- a/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/Parser/ModemConfParser.java
+++ b/hardware/OpenCustomizationSelector/src/com/sonymobile/customizationselector/Parser/ModemConfParser.java
@@ -75,6 +75,9 @@ public class ModemConfParser {
                 CSLog.e(TAG, "IOException: while closing reader", e);
             }
         }
+        if (modemVariant == "" || modemVariant == null) {
+            modemVariant = "ir51_ir92_ims";
+        }
         CSLog.d(TAG, "Parsed modem: '" + modemVariant + "'");
         return modemVariant;
     }

--- a/hardware/XperiaParts/res/values/strings.xml
+++ b/hardware/XperiaParts/res/values/strings.xml
@@ -38,7 +38,7 @@
     <string name="sim_slot">Sim Slot</string>
     <string name="sim_slot_summary">Select the sim slot you want network switcher to work for.\nSelected Slot: </string>
     <string name="ims_title">IMS Features</string>
-    <string name="ims_summary">Enables IMS features, such as VoLTE, VoWiFi and WiFi calling, <b>if possible</b>.</string>
+    <string name="ims_summary">Enables IMS features, such as VoLTE, VoWiFi and ViLTE, <b>if possible</b>.</string>
     <string name="modem_title">Re-apply Modem</string>
     <string name="modem_summary">With enabled IMS, the modem crashes for some carriers if the mbn is not applied at every boot. Use this option to potentially fix such issues.</string>
     <string name="ultra_dim_name">Ultra-Dim</string>

--- a/hardware/XperiaParts/res/values/strings.xml
+++ b/hardware/XperiaParts/res/values/strings.xml
@@ -38,7 +38,7 @@
     <string name="sim_slot">Sim Slot</string>
     <string name="sim_slot_summary">Select the sim slot you want network switcher to work for.\nSelected Slot: </string>
     <string name="ims_title">IMS Features</string>
-    <string name="ims_summary">Enables features such as IMS, VoLTE, VoWiFi or WiFi calling <b>if it worked on stock</b>.</string>
+    <string name="ims_summary">Enables IMS features, such as VoLTE, VoWiFi and WiFi calling, <b>if possible</b>.</string>
     <string name="modem_title">Re-apply Modem</string>
     <string name="modem_summary">With enabled IMS, the modem crashes for some carriers if the mbn is not applied at every boot. Use this option to potentially fix such issues.</string>
     <string name="ultra_dim_name">Ultra-Dim</string>

--- a/hardware/XperiaParts/res/xml/device_settings.xml
+++ b/hardware/XperiaParts/res/xml/device_settings.xml
@@ -51,14 +51,14 @@
             android:title="@string/ims_title" />
 
         <SwitchPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:icon="@drawable/ic_outline_phonelink_setup_24"
             android:key="cs_re_apply_modem"
             android:summary="@string/modem_summary"
             android:title="@string/modem_title" />
 
         <SwitchPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:icon="@drawable/ic_outline_notifications_active_24"
             android:key="cs_notification"
             android:summary="@string/sony_modem_notification_summary"

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -200,7 +200,7 @@
     <bool name="config_cellBroadcastAppLinks">true</bool>
 
     <!-- Is the device capable of hot swapping an ICC Card -->
-    <bool name="config_hotswapCapable">true</bool>
+    <bool name="config_hotswapCapable">false</bool>
 
     <!-- Flag specifying whether VoLTE & VT is available on device -->
     <bool name="config_device_volte_available">true</bool>


### PR DESCRIPTION
Changes done to accomodate for new IMS features. Please review and offer feedback.

For `hardware/XperiaParts/res/device_settings.xml`, also set Customization Switcher notification default to off, instead of on, since its only use is debugging and causes confusion to those that don't need it.