### PR TITLE
Sony Camera app fix

### DIFF
--- a/sepolicy/vendor/cacaoserver.te
+++ b/sepolicy/vendor/cacaoserver.te
@@ -11,18 +11,22 @@ add_service(cacaoserver, cacaoserver_service)
 binder_use(cacaoserver)
 hwbinder_use(cacaoserver)
 get_prop(cacaoserver, hwservicemanager_prop)
+
 binder_call(cacaoserver, hal_camera_somc)
-binder_call(cacaoserver, mediaserver)
-binder_call(cacaoserver, mediacodec)
-binder_call(cacaoserver, system_server)
-binder_call(cacaoserver, platform_app)
 binder_call(cacaoserver, hal_graphics_allocator_default)
+binder_call(cacaoserver, mediacodec)
+binder_call(cacaoserver, mediaserver)
+binder_call(cacaoserver, platform_app)
+binder_call(cacaoserver, system_server)
+binder_call(cacaoserver, sonycamera_app)
 
 hal_client_domain(cacaoserver, hal_camera)
 hal_client_domain(cacaoserver, hal_graphics_allocator)
 
 allow cacaoserver hal_graphics_mapper_hwservice:hwservice_manager find;
 allow cacaoserver hidl_token_hwservice:hwservice_manager find;
+allow cacaoserver sonycamera_app:binder call;
+allow cacaoserver sonycamera_app:fd use;
 
 allow cacaoserver permission_service:service_manager find;
 

--- a/sepolicy/vendor/crash_dump.te
+++ b/sepolicy/vendor/crash_dump.te
@@ -1,4 +1,10 @@
 # crash_dump.te
 
+allow crash_dump device_config_runtime_native_boot_prop:file { getattr open };
+allow crash_dump device_config_runtime_native_prop:file { getattr open };
 allow crash_dump hwservicemanager_prop:file { getattr open };
+allow crash_dump packagemanager_config_prop:file { getattr open };
+allow crash_dump qemu_sf_lcd_density_prop:file { getattr open };
+allow crash_dump resourcecache_data_file:file read;
 allow crash_dump vendor_display_prop:file { getattr open };
+allow crash_dump vendor_persist_camera_prop:file { getattr open };

--- a/sepolicy/vendor/seapp_contexts
+++ b/sepolicy/vendor/seapp_contexts
@@ -1,8 +1,8 @@
 user=radio seinfo=platform name=.qtidataservices domain=qtidataservices_app type=radio_data_file
-user=_app seinfo=platform name=com.sonyericsson.android.camera domain=sonycamera_app type=app_data_file
-user=_app seinfo=platform name=com.sonymobile.addoncamera.portraitselfie domain=sonycamera_app type=app_data_file
-user=_app seinfo=platform name=com.sonyericsson.android.addoncamera.artfilter domain=sonycamera_app type=app_data_file
-user=_app seinfo=platform name=com.sonyericsson.android.camera3d domain=sonycamera_app type=app_data_file
+user=_app seinfo=platform name=com.sonyericsson.android.camera domain=sonycamera_app type=app_data_file levelFrom=all
+user=_app seinfo=platform name=com.sonymobile.addoncamera.portraitselfie domain=sonycamera_app type=app_data_file levelFrom=all
+user=_app seinfo=platform name=com.sonyericsson.android.addoncamera.artfilter domain=sonycamera_app type=app_data_file levelFrom=all
+user=_app seinfo=platform name=com.sonyericsson.android.camera3d domain=sonycamera_app type=app_data_file levelFrom=all
 
 # TimeService app
-user=system seinfo=platform name=com.qualcomm.timeservice domain=qtimeservice type=system_app_data_file
+user=system seinfo=platform name=com.qualcomm.timeservice domain=qtimeservice type=system_app_data_file levelFrom=all

--- a/sepolicy/vendor/sonycamera_app.te
+++ b/sepolicy/vendor/sonycamera_app.te
@@ -18,6 +18,7 @@ allow sonycamera_app audioserver_service:service_manager find;
 allow sonycamera_app autofill_service:service_manager find;
 allow sonycamera_app batteryproperties_service:service_manager find;
 allow sonycamera_app batterystats_service:service_manager find;
+allow sonycamera_app cacaoserver_service:service_manager find;
 allow sonycamera_app cameraserver_service:service_manager find;
 allow sonycamera_app content_capture_service:service_manager find;
 allow sonycamera_app device_policy_service:service_manager find;
@@ -41,5 +42,6 @@ allow sonycamera_app wifi_service:service_manager find;
 
 allow sonycamera_app idd_service:service_manager find;
 
+binder_call(sonycamera_app, cacaoserver)
 binder_call(sonycamera_app, gpuservice)
 binder_call(sonycamera_app, hal_secd_default)


### PR DESCRIPTION
Hello,

This is a pull request aimed to fix the Sony Camera app by patching its SEPolicy, based on errors that have occurred in `logcat`, using `audit2allow` suggestions.

`crash_dump` SEPolicy was also changed due to some SEPolicy errors appearing in `logcat`.